### PR TITLE
Fix pullup value for chamber thermistor

### DIFF
--- a/head.cfg
+++ b/head.cfg
@@ -127,6 +127,7 @@ max_temp: 100
 [temperature_sensor Chamber_on_M36]
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: head:PA2
+pullup_resistor: 10000
 min_temp: 0
 max_temp: 100
 

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ M36 is divided into two versions, mainly because of the difference in motor driv
 | INPUT          | 0.5mm 2x16 BTB connector | Max 24v 7A input, CAN_TX/USBPM=PA12, CAN_RX/USBDM=PA11       |
 | T0             | PH2.0-2P                 | PA0，ADC，4.7K pull-up to 3.3V                               |
 | T1             | PH2.0-2P                 | PA3，ADC，4.7K pull-up to 3.3V                               |
-| TB             | no connector             | PA2，ADC，4.7K pull-up to 3.3V, onboard 100K /3950 thermistor |
+| TB             | no connector             | PA2，ADC，10K pull-up to 3.3V, onboard 100K /3950 thermistor |
 | HEAT           | XH2.54-2P                | PA8，MAX 3A，PWM output，max power recommended: 24V/70W      |
 | FAN0           | PH2.0-2P                 | Enable: PB11, (4pin fan = enable, 2pin/3pin fan = PWM control pin)<br/>TACH: PB12, <br/>PWM: PB10, (only for 4pin fan)<br/>0.5A MAX PWM，for fan control (default VIN，5V selectable) |
 | FAN1           | PH2.0-4P                 | Enable: PB4, (4pin fan = enable, 2pin/3pin fan = PWM control pin)<br/>TACH: PB3, <br/>PWM: PA15, (only for 4pin fan)<br/>0.5A MAX PWM，for fan control (default VIN，5V selectable) |


### PR DESCRIPTION
The documentation claims that the TB thermistor uses a pullup resistor of 4.7 kOhm. This results a highly erroneous reading. Looking at the schematic, a 10kOhm resistor is actually used. Setting the pullup resistor to 10000 in Klipper indeed fixes this reading, so I conclude that this is a documentation error and the pullup should be 10kOhm.